### PR TITLE
Fix NullPointerException when call reset method

### DIFF
--- a/faimageview/src/main/java/kr/pe/burt/android/lib/faimageview/FAImageView.java
+++ b/faimageview/src/main/java/kr/pe/burt/android/lib/faimageview/FAImageView.java
@@ -186,8 +186,10 @@ public class FAImageView extends ImageView {
 
     public void reset() {
         stopAnimation();
-        drawableList.clear();
-        drawableList = null;
+        if(drawableList != null){
+            drawableList.clear();
+            drawableList = null; 
+        }
         currentFrameIndex = -1;
     }
 


### PR DESCRIPTION
If we call reset() method before calling addImageFrame(), it will throw NullPointerException.
So we have to prevent this exception.
